### PR TITLE
fix 'Package array Error: Empty preamble: `l' used' error if using nbconvert to pdf

### DIFF
--- a/numpyarray_to_latex/main.py
+++ b/numpyarray_to_latex/main.py
@@ -141,7 +141,7 @@ def to_ltx(a,
 
         colstr += '}'
     else:
-        colstr = '{}'
+        colstr = '{' + ('l' * ncol) + '}'
 
     out += r'\begin{' + latexarraytype + '}' +colstr+'\n'
 


### PR DESCRIPTION
Fixes the error

```
! Package array Error: Empty preamble: `l' used.

See the array package documentation for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.416 \begin{array}{}
                     
? 
! Emergency stop.
 ...                                              
                                                  
l.416 \begin{array}{}
```

if one wants to create a pdf file from a notebook using this tool. (Export done via nbconvert)